### PR TITLE
Fix status of pre-bound volumes.

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -372,6 +372,12 @@ func syncPV(pv *PV) {
 				}
 			} else {
 				// The PV must have been created with this ptr; leave it alone.
+				// The binding is not complete, mark the volume appropriately.
+				pv.Status.Phase = Available
+				if err := CommitPVStatus(pv.Status); err != nil {
+					// Status was not saved. syncPV will set the status
+					return
+				}
 			}
 		}
 	}


### PR DESCRIPTION
There is one corner case where we don't (re)set pv.Status properly:

When a volume is pre-bound by user to a claim and the claim is bound somewhere else, we should mark the volume as Available, as the binding is not complete yet.

@pmorie @childsb @swagiaal @thockin @saad-ali 
