### PR TITLE
Don't overwrite Failed state with Released.

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -284,13 +284,17 @@ func syncPV(pv *PV) {
 			// NOTE: releasePV may either release the PV back into the pool or
 			// recycle it or do nothing (retain)
 
-			// HOWTO RELEASE A PV
-			pv.Status.Phase = Released
-			if err := CommitPVStatus(pv); err != nil {
-				// Status was not saved; we will fall back into the same
-				// condition in the next call to this method
-				return
+			// Make sure we don't overwrite previous failure of
+			// recycler/deleter.
+			if pv.Status.Phase != Failed {
+				pv.Status.Phase = Released
+				if err := CommitPVStatus(pv); err != nil {
+					// Status was not saved; we will fall back into the same
+					// condition in the next call to this method
+					return
+				}
 			}
+			// HOWTO RELEASE A PV
 			if pv.Spec.ReclaimPolicy == "Retain" {
 				return
 			} else if pv.Spec.ReclaimPolicy == "Delete" {


### PR DESCRIPTION
Consider this sequence:
1. A volume is "Bound" and someone removes appropriate claim.
2. The controller marks the volume as "Released" and starts recycling. Note that this produces "volume changed" event (status changed to Recycling).
3. The recycler fails (e.g. no plugin is configured for the volume) and marks the volume as "Failed". Another "volume changed" event.
4. syncVolume() evaluates the changed volume and reaches the same code path as in 2. and marks the volume as "Released" again.
5. The recycler fails again and marks the volume "Failed" again.
6. go to 4.

To cut this endless loop, we should not overwrite Failed state with Released. Let the user see that something went wrong.

@thockin @saad-ali @rootfs @swagiaal @childsb @pmorie
